### PR TITLE
update import statement

### DIFF
--- a/armstrong/core/tt_sections/utils.py
+++ b/armstrong/core/tt_sections/utils.py
@@ -1,6 +1,6 @@
-from django.conf import settings
-from django.utils.module_loading import import_module
+from importlib import import_module
 
+from django.conf import settings
 
 def get_module_and_model_names():
     s = (getattr(settings, "ARMSTRONG_SECTION_ITEM_MODEL", False) or

--- a/armstrong/core/tt_sections/utils.py
+++ b/armstrong/core/tt_sections/utils.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.importlib import import_module
+from django.utils.module_loading import import_module
 
 
 def get_module_and_model_names():


### PR DESCRIPTION
Fixes the following django deprecation warning in `texastribune`:

`/usr/local/lib/python2.7/dist-packages/armstrong/core/arm_sections/utils.py:2: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
from django.utils.importlib import import_module`